### PR TITLE
Version updated from v0.1.1 to v0.1.2

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.1.1"
+current_version = "v0.1.2"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.1.1`
+`v0.1.2`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.1.1"
+version = "v0.1.2"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"
@@ -42,7 +42,7 @@ requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-data]
-"totypes" = ["py.typed"]
+"invrs_opt" = ["py.typed"]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]  # Allow tests with same name in different dirs.

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.1.1"
+__version__ = "v0.1.2"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt.lbfgsb.lbfgsb import lbfgsb as lbfgsb


### PR DESCRIPTION
The source of the missing py.typed was identified -- the pyproject.toml was wrong. This PR should fix it.