### PR TITLE
Fix lbfgsb for cases where the params pytree includes `None`

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.1.3"
+current_version = "v0.1.4"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.1.3`
+`v0.1.4`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.1.3"
+version = "v0.1.4"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.1.3"
+__version__ = "v0.1.4"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt.lbfgsb.lbfgsb import lbfgsb as lbfgsb

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 import jax
 import jax.numpy as jnp
 import numpy as onp
+from jax import flatten_util
 from jax import tree_util
 from scipy.optimize._lbfgsb_py import (  # type: ignore[import-untyped]
     _lbfgsb as scipy_lbfgsb,
@@ -245,13 +246,14 @@ def transformed_lbfgsb(
 
 def _to_numpy(params: PyTree) -> NDArray:
     """Flattens a `params` pytree into a single rank-1 numpy array."""
-    leaves = tree_util.tree_leaves(params)
-    x_numpy: NDArray = onp.concatenate([onp.asarray(leaf).flatten() for leaf in leaves])
-    return x_numpy.astype(onp.float64)
+    x, _ = flatten_util.ravel_pytree(params)
+    return onp.asarray(x, dtype=onp.float64)
 
 
 def _to_pytree(x_flat: NDArray, params: PyTree) -> PyTree:
     """Restores a pytree from a flat numpy array using the structure of `params`.
+
+    Note that the returned pytree includes jax array leaves.
 
     Args:
         x_flat: The rank-1 numpy array to be restored.
@@ -259,17 +261,10 @@ def _to_pytree(x_flat: NDArray, params: PyTree) -> PyTree:
             pytree.
 
     Returns:
-        The restored pytree.
+        The restored pytree, with jax array leaves.
     """
-    leaves, treedef = tree_util.tree_flatten(params)
-    indices_or_sections = onp.cumsum([onp.size(leaf) for leaf in leaves])
-    x_split_flat = onp.split(x_flat, indices_or_sections)
-    x_split = [x.reshape(onp.shape(leaf)) for x, leaf in zip(x_split_flat, leaves)]
-    x_split_jax = [
-        jnp.asarray(x) if isinstance(leaf, jnp.ndarray) else x
-        for x, leaf in zip(x_split, leaves)
-    ]
-    return tree_util.tree_unflatten(treedef, x_split_jax)
+    _, unflatten_fn = flatten_util.ravel_pytree(params)
+    return unflatten_fn(jnp.asarray(x_flat, dtype=float))
 
 
 def _bound_for_params(bound: PyTree, params: PyTree) -> ElementwiseBound:

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -320,6 +320,8 @@ def _bound_for_params(bound: PyTree, params: PyTree) -> ElementwiseBound:
 
     bound_flat = []
     for b, p in zip(bound_leaves, params_leaves):
+        if p is None:
+            continue
         if b is None or onp.isscalar(b) or onp.shape(b) == ():
             bound_flat += [b] * onp.size(p)
         else:

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -246,7 +246,7 @@ def transformed_lbfgsb(
 
 def _to_numpy(params: PyTree) -> NDArray:
     """Flattens a `params` pytree into a single rank-1 numpy array."""
-    x, _ = flatten_util.ravel_pytree(params)
+    x, _ = flatten_util.ravel_pytree(params)  # type: ignore[no-untyped-call]
     return onp.asarray(x, dtype=onp.float64)
 
 
@@ -263,7 +263,7 @@ def _to_pytree(x_flat: NDArray, params: PyTree) -> PyTree:
     Returns:
         The restored pytree, with jax array leaves.
     """
-    _, unflatten_fn = flatten_util.ravel_pytree(params)
+    _, unflatten_fn = flatten_util.ravel_pytree(params)  # type: ignore[no-untyped-call]
     return unflatten_fn(jnp.asarray(x_flat, dtype=float))
 
 

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -297,6 +297,20 @@ class LbfgsbTest(unittest.TestCase):
                     ),
                 }
             ],
+            [
+                {
+                    "a": types.Density2DArray(
+                        array=jnp.ones((3, 3)),
+                        lower_bound=0.0,
+                        upper_bound=1.0,
+                        fixed_solid=None,
+                        fixed_void=None,
+                        minimum_width=1,
+                        minimum_spacing=1,
+                    ),
+                    "b": None,
+                }
+            ],
         ]
     )
     def test_initialize(self, params):

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -424,7 +424,7 @@ class ConverterTest(unittest.TestCase):
             jax.tree_util.tree_leaves(restored_params),
         ):
             self.assertTrue(isinstance(a, onp.ndarray))
-            self.assertTrue(isinstance(b, onp.ndarray))
+            self.assertTrue(isinstance(b, jnp.ndarray))
             onp.testing.assert_array_equal(a, b)
 
 


### PR DESCRIPTION
This PR fixes the case where the params pytree includes `None`, and adds a test. Also simplifies some internal functions by making use of `jax.flatten_util`.