### PR TITLE
Allow vmap of lbfgsb optimization

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.1.4"
+current_version = "v0.2.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.1.4`
+`v0.2.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.1.4"
+version = "v0.2.0"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -6,5 +6,5 @@ Copyright (c) 2023 The INVRS-IO authors.
 __version__ = "v0.1.4"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
-from invrs_opt.lbfgsb.lbfgsb import lbfgsb as lbfgsb
 from invrs_opt.lbfgsb.lbfgsb import density_lbfgsb as density_lbfgsb
+from invrs_opt.lbfgsb.lbfgsb import lbfgsb as lbfgsb

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.1.4"
+__version__ = "v0.2.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt.lbfgsb.lbfgsb import density_lbfgsb as density_lbfgsb

--- a/src/invrs_opt/base.py
+++ b/src/invrs_opt/base.py
@@ -12,13 +12,15 @@ PyTree = Any
 class InitFn(Protocol):
     """Callable which initializes an optimizer state."""
 
-    def __call__(self, params: PyTree) -> PyTree: ...
+    def __call__(self, params: PyTree) -> PyTree:
+        ...
 
 
 class ParamsFn(Protocol):
     """Callable which returns the parameters for an optimizer state."""
 
-    def __call__(self, state: PyTree) -> PyTree: ...
+    def __call__(self, state: PyTree) -> PyTree:
+        ...
 
 
 class UpdateFn(Protocol):
@@ -31,7 +33,8 @@ class UpdateFn(Protocol):
         value: float,
         params: PyTree,
         state: PyTree,
-    ) -> PyTree: ...
+    ) -> PyTree:
+        ...
 
 
 @dataclasses.dataclass

--- a/src/invrs_opt/base.py
+++ b/src/invrs_opt/base.py
@@ -12,15 +12,13 @@ PyTree = Any
 class InitFn(Protocol):
     """Callable which initializes an optimizer state."""
 
-    def __call__(self, params: PyTree) -> PyTree:
-        ...
+    def __call__(self, params: PyTree) -> PyTree: ...
 
 
 class ParamsFn(Protocol):
     """Callable which returns the parameters for an optimizer state."""
 
-    def __call__(self, state: PyTree) -> PyTree:
-        ...
+    def __call__(self, state: PyTree) -> PyTree: ...
 
 
 class UpdateFn(Protocol):
@@ -33,8 +31,7 @@ class UpdateFn(Protocol):
         value: float,
         params: PyTree,
         state: PyTree,
-    ) -> PyTree:
-        ...
+    ) -> PyTree: ...
 
 
 @dataclasses.dataclass

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -11,8 +11,8 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from jax import flatten_util, tree_util
-from scipy.optimize._lbfgsb_py import (
-    _lbfgsb as scipy_lbfgsb,  # type: ignore[import-untyped]
+from scipy.optimize._lbfgsb_py import (  # type: ignore[import-untyped]
+    _lbfgsb as scipy_lbfgsb,
 )
 from totypes import types
 

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -11,7 +11,9 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from jax import flatten_util, tree_util
-from scipy.optimize._lbfgsb_py import _lbfgsb as scipy_lbfgsb  # type: ignore[import-untyped]
+from scipy.optimize._lbfgsb_py import (  # type: ignore[import-untyped]
+    _lbfgsb as scipy_lbfgsb,
+)
 from totypes import types
 
 from invrs_opt import base

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from jax import flatten_util, tree_util
-import scipy.optimize._lbfgsb_py._lbfgsb as scipy_lbfgsb  # type: ignore[import-untyped]
+from scipy.optimize._lbfgsb_py import _lbfgsb as scipy_lbfgsb  # type: ignore[import-untyped]
 from totypes import types
 
 from invrs_opt import base
@@ -615,7 +615,9 @@ def _configure_bounds(
 def _array_from_s60_str(s60_str: NDArray) -> jnp.ndarray:
     """Return a jax array for a numpy s60 string."""
     assert s60_str.shape == (1,)
-    return jnp.asarray([int(o) for o in s60_str[0]], dtype=int)
+    chars = [int(o) for o in s60_str[0]]
+    chars.extend([32] * (59 - len(chars)))
+    return jnp.asarray(chars, dtype=int)
 
 
 def _s60_str_from_array(array: jnp.ndarray) -> NDArray:

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -11,9 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from jax import flatten_util, tree_util
-from scipy.optimize._lbfgsb_py import (  # type: ignore[import-untyped]
-    _lbfgsb as scipy_lbfgsb,
-)
+import scipy.optimize._lbfgsb_py._lbfgsb as scipy_lbfgsb  # type: ignore[import-untyped]
 from totypes import types
 
 from invrs_opt import base

--- a/src/invrs_opt/lbfgsb/transform.py
+++ b/src/invrs_opt/lbfgsb/transform.py
@@ -8,7 +8,6 @@ from typing import Tuple, Union
 import jax
 import jax.numpy as jnp
 from jax import tree_util
-
 from totypes import types
 
 PadMode = Union[str, Tuple[str, str]]

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -7,6 +7,7 @@ import unittest
 
 import jax
 import jax.numpy as jnp
+from jax import flatten_util
 import numpy as onp
 from parameterized import parameterized
 import scipy.optimize as spo
@@ -342,6 +343,49 @@ class LbfgsbTest(unittest.TestCase):
             state = opt.update(value=value, grad=grad, params=density, state=state)
 
         onp.testing.assert_allclose(density.array, 1.0)
+
+    def test_optimization_with_vmap(self):
+        def initial_params_fn(key):
+            ka, kb = jax.random.split(key)
+            return {"a": jax.random.normal(ka, (10,)), "b": jax.random.normal(kb, (10,))}
+
+        def loss_fn(params):
+            flat, _ = flatten_util.ravel_pytree(params)
+            return jnp.sum(jnp.abs(flat**2))
+        
+        keys = jax.random.split(jax.random.PRNGKey(0))
+        opt = lbfgsb.lbfgsb(maxcor=20)
+
+        # Test batch optimization
+        params = jax.vmap(initial_params_fn)(keys)
+        state = jax.vmap(opt.init)(params)
+
+        @jax.jit
+        @jax.vmap
+        def step_fn(state):
+            params = opt.params(state)
+            value, grad = jax.value_and_grad(loss_fn)(params)
+            state = opt.update(grad=grad, value=value, params=params, state=state)
+            return state, value
+
+        batch_values = []
+        for i in range(10):
+            state, value = step_fn(state)
+            batch_values.append(value)
+
+        # Test one-at-a-time optimization.
+        no_batch_values = []
+        for k in keys:
+            no_batch_values.append([])
+            params = initial_params_fn(k)
+            state = opt.init(params)
+            for _ in range(10):
+                params = opt.params(state)
+                value, grad = jax.jit(jax.value_and_grad(loss_fn))(params)
+                state = opt.update(grad=grad, value=value, params=params, state=state)
+                no_batch_values[-1].append(value)
+
+        onp.testing.assert_array_equal(batch_values, onp.transpose(no_batch_values, (1, 0)))
 
 
 class BoundsForParamsTest(unittest.TestCase):

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -7,13 +7,13 @@ import unittest
 
 import jax
 import jax.numpy as jnp
-from jax import flatten_util
 import numpy as onp
-from parameterized import parameterized
 import scipy.optimize as spo
+from jax import flatten_util
+from parameterized import parameterized
+from totypes import types
 
 from invrs_opt.lbfgsb import lbfgsb
-from totypes import types
 
 
 class DensityLbfgsbBoundsTest(unittest.TestCase):

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -347,12 +347,15 @@ class LbfgsbTest(unittest.TestCase):
     def test_optimization_with_vmap(self):
         def initial_params_fn(key):
             ka, kb = jax.random.split(key)
-            return {"a": jax.random.normal(ka, (10,)), "b": jax.random.normal(kb, (10,))}
+            return {
+                "a": jax.random.normal(ka, (10,)),
+                "b": jax.random.normal(kb, (10,)),
+            }
 
         def loss_fn(params):
             flat, _ = flatten_util.ravel_pytree(params)
             return jnp.sum(jnp.abs(flat**2))
-        
+
         keys = jax.random.split(jax.random.PRNGKey(0))
         opt = lbfgsb.lbfgsb(maxcor=20)
 
@@ -385,7 +388,9 @@ class LbfgsbTest(unittest.TestCase):
                 state = opt.update(grad=grad, value=value, params=params, state=state)
                 no_batch_values[-1].append(value)
 
-        onp.testing.assert_array_equal(batch_values, onp.transpose(no_batch_values, (1, 0)))
+        onp.testing.assert_array_equal(
+            batch_values, onp.transpose(no_batch_values, (1, 0))
+        )
 
 
 class BoundsForParamsTest(unittest.TestCase):

--- a/tests/lbfgsb/test_transform.py
+++ b/tests/lbfgsb/test_transform.py
@@ -10,9 +10,9 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from parameterized import parameterized
+from totypes import types
 
 from invrs_opt.lbfgsb import transform
-from totypes import types
 
 
 class GaussianFilterTest(unittest.TestCase):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -10,9 +10,9 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 import parameterized
+from totypes import json_utils, symmetry, types
 
 import invrs_opt
-from totypes import json_utils, symmetry, types
 
 jax.config.update("jax_enable_x64", True)
 


### PR DESCRIPTION
This PR enable multiple optimization problems to be solved in parallel using the `lbfgsb` optimizer.

Solving problems in parallel can help make efficient use of hardware. This is achieved using `jax.pure_callback` in the `init` and `update` methods of the `lbfgsb` optimizer. We also add a test which carries out batch optimization.