### PR TITLE
Simplify pure_callback functions and improve latent initialization

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.2.0"
+current_version = "v0.3.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.2.0`
+`v0.3.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.2.0"
+version = "v0.3.0"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.2.0"
+__version__ = "v0.3.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt.lbfgsb.lbfgsb import density_lbfgsb as density_lbfgsb

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -158,6 +158,7 @@ def density_lbfgsb(
         array = jnp.clip(array, -1, 1)
         array *= jnp.tanh(beta)
         latent_array = jnp.arctanh(array) / beta
+        latent_array = transform.rescale_array_for_density(latent_array, density)
         return dataclasses.replace(density, array=latent_array)
 
     return transformed_lbfgsb(

--- a/src/invrs_opt/lbfgsb/lbfgsb.py
+++ b/src/invrs_opt/lbfgsb/lbfgsb.py
@@ -11,8 +11,8 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 from jax import flatten_util, tree_util
-from scipy.optimize._lbfgsb_py import (  # type: ignore[import-untyped]
-    _lbfgsb as scipy_lbfgsb,
+from scipy.optimize._lbfgsb_py import (
+    _lbfgsb as scipy_lbfgsb,  # type: ignore[import-untyped]
 )
 from totypes import types
 
@@ -22,7 +22,8 @@ from invrs_opt.lbfgsb import transform
 NDArray = onp.ndarray[Any, Any]
 PyTree = Any
 ElementwiseBound = Union[NDArray, Sequence[Optional[float]]]
-LbfgsbState = Tuple[PyTree, Dict[str, jnp.ndarray]]
+JaxLbfgsbDict = Dict[str, jnp.ndarray]
+LbfgsbState = Tuple[PyTree, PyTree, JaxLbfgsbDict]
 
 
 # Task message prefixes for the underlying L-BFGS-B implementation.
@@ -188,7 +189,7 @@ def transformed_lbfgsb(
     def init_fn(params: PyTree) -> LbfgsbState:
         """Initializes the optimization state."""
 
-        def _init_pure(params: PyTree) -> LbfgsbState:
+        def _init_pure(params: PyTree) -> Tuple[PyTree, JaxLbfgsbDict]:
             lower_bound = types.extract_lower_bound(params)
             upper_bound = types.extract_upper_bound(params)
             scipy_lbfgsb_state = ScipyLbfgsbState.init(
@@ -199,16 +200,19 @@ def transformed_lbfgsb(
                 line_search_max_steps=line_search_max_steps,
             )
             latent_params = _to_pytree(scipy_lbfgsb_state.x, params)
-            params = transform_fn(latent_params)
-            return params, scipy_lbfgsb_state.to_jax()
+            return latent_params, scipy_lbfgsb_state.to_jax()
 
-        return jax.pure_callback(  # type: ignore[no-any-return, attr-defined]
+        (
+            latent_params,
+            jax_lbfgsb_state,
+        ) = jax.pure_callback(  # type: ignore[attr-defined]
             _init_pure, _example_state(params, maxcor), params
         )
+        return transform_fn(latent_params), latent_params, jax_lbfgsb_state
 
     def params_fn(state: LbfgsbState) -> PyTree:
         """Returns the parameters for the given `state`."""
-        params, _ = state
+        params, _, _ = state
         return params
 
     def update_fn(
@@ -219,30 +223,36 @@ def transformed_lbfgsb(
         state: LbfgsbState,
     ) -> LbfgsbState:
         """Updates the state."""
+        del params
 
         def _update_pure(
-            grad: PyTree, value: float, params: PyTree, state: LbfgsbState
-        ) -> LbfgsbState:
-            del params
-
-            params, jax_lbfgsb_state = state
-            scipy_lbfgsb_state = ScipyLbfgsbState.from_jax(jax_lbfgsb_state)
-
-            latent_params = _to_pytree(scipy_lbfgsb_state.x, params)
-            _, vjp_fn = jax.vjp(transform_fn, latent_params)
-            (latent_grad,) = vjp_fn(grad)
-
+            latent_grad: PyTree,
+            value: jnp.ndarray,
+            jax_lbfgsb_state: JaxLbfgsbDict,
+        ) -> Tuple[PyTree, JaxLbfgsbDict]:
             assert onp.size(value) == 1
+            scipy_lbfgsb_state = ScipyLbfgsbState.from_jax(jax_lbfgsb_state)
             scipy_lbfgsb_state.update(
                 grad=_to_numpy(latent_grad), value=onp.asarray(value)
             )
-            latent_params = _to_pytree(scipy_lbfgsb_state.x, params)
-            params = transform_fn(latent_params)
-            return params, scipy_lbfgsb_state.to_jax()
+            latent_params = _to_pytree(scipy_lbfgsb_state.x, latent_grad)
+            return latent_params, scipy_lbfgsb_state.to_jax()
 
-        return jax.pure_callback(  # type: ignore[no-any-return, attr-defined]
-            _update_pure, state, grad, value, params, state
+        params, latent_params, jax_lbfgsb_state = state
+        _, vjp_fn = jax.vjp(transform_fn, latent_params)
+        (latent_grad,) = vjp_fn(grad)
+
+        (
+            latent_params,
+            jax_lbfgsb_state,
+        ) = jax.pure_callback(  # type: ignore[attr-defined]
+            _update_pure,
+            (latent_params, jax_lbfgsb_state),
+            latent_grad,
+            value,
+            jax_lbfgsb_state,
         )
+        return transform_fn(latent_params), latent_params, jax_lbfgsb_state
 
     return base.Optimizer(
         init=init_fn,


### PR DESCRIPTION
Remove some jax code from the pure callback functions, so that they can be jit-compiled. This should address an issue where on GPUs, the pure callback functions caused hanging.

Also, improved initialization of latent parameters, so that the parameters for the initial optimizer state are closer to the parameters provided during initialization.