### PR TITLE
Fixes to allow jit

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.3.0"
+current_version = "v0.3.1"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.3.0`
+`v0.3.1`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.3.0"
+version = "v0.3.1"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.3.0"
+__version__ = "v0.3.1"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt.lbfgsb.lbfgsb import density_lbfgsb as density_lbfgsb

--- a/src/invrs_opt/lbfgsb/transform.py
+++ b/src/invrs_opt/lbfgsb/transform.py
@@ -156,7 +156,8 @@ def _pad_mode_for_density(density: types.Density2DArray) -> Union[str, Tuple[str
 
 def _gaussian_kernel(fwhm: float, fwhm_size_multiple: float) -> jnp.ndarray:
     """Returns a Gaussian kernel with the specified full-width at half-maximum."""
-    kernel_size = max(1, int(jnp.ceil(fwhm * fwhm_size_multiple)))
+    with jax.ensure_compile_time_eval():
+        kernel_size = max(1, int(jnp.ceil(fwhm * fwhm_size_multiple)))
     # Ensure the kernel size is odd, so that there is always a central pixel which will
     # contain the peak value of the Gaussian.
     kernel_size += (kernel_size + 1) % 2

--- a/tests/lbfgsb/test_lbfgsb.py
+++ b/tests/lbfgsb/test_lbfgsb.py
@@ -388,6 +388,7 @@ class LbfgsbTest(unittest.TestCase):
             return {
                 "a": jax.random.normal(ka, (10,)),
                 "b": jax.random.normal(kb, (10,)),
+                "c": types.Density2DArray(array=jnp.ones((3, 3))),
             }
 
         def loss_fn(params):
@@ -395,7 +396,7 @@ class LbfgsbTest(unittest.TestCase):
             return jnp.sum(jnp.abs(flat**2))
 
         keys = jax.random.split(jax.random.PRNGKey(0))
-        opt = lbfgsb.lbfgsb(maxcor=20)
+        opt = lbfgsb.density_lbfgsb(beta=2, maxcor=20)
 
         # Test batch optimization
         params = jax.vmap(initial_params_fn)(keys)
@@ -426,7 +427,7 @@ class LbfgsbTest(unittest.TestCase):
                 state = opt.update(grad=grad, value=value, params=params, state=state)
                 no_batch_values[-1].append(value)
 
-        onp.testing.assert_array_equal(
+        onp.testing.assert_allclose(
             batch_values, onp.transpose(no_batch_values, (1, 0))
         )
 


### PR DESCRIPTION
Moving some functionality out of a `jax.pure_callback` call broke the ability to jit-compile. This PR fixes it, and adds a test ensuring that optimization with densities can be jit-compiled.