### PR TITLE
Add `update` function to parameterization API

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.7.2"
+current_version = "v0.8.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-opt - Optimization algorithms for inverse design
-`v0.7.2`
+`v0.8.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_opt"
-version = "v0.7.2"
+version = "v0.8.0"
 description = "Algorithms for inverse design"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_opt/__init__.py
+++ b/src/invrs_opt/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.7.2"
+__version__ = "v0.8.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 from invrs_opt import parameterization as parameterization

--- a/src/invrs_opt/parameterization/base.py
+++ b/src/invrs_opt/parameterization/base.py
@@ -44,6 +44,13 @@ class ConstraintsFn(Protocol):
         ...
 
 
+class UpdateFn(Protocol):
+    """Performs the required update of a parameterized density for the given step."""
+
+    def __call__(self, params: PyTree, step: int) -> PyTree:
+        ...
+
+
 @dataclasses.dataclass
 class Density2DParameterization:
     """Stores `(from_density, to_density, constraints)` function triple."""
@@ -51,6 +58,7 @@ class Density2DParameterization:
     from_density: FromDensityFn
     to_density: ToDensityFn
     constraints: ConstraintsFn
+    update: UpdateFn
 
 
 @dataclasses.dataclass

--- a/src/invrs_opt/parameterization/filter_project.py
+++ b/src/invrs_opt/parameterization/filter_project.py
@@ -85,8 +85,14 @@ def filter_project(beta: float) -> base.Density2DParameterization:
         del params
         return jnp.asarray(0.0)
 
+    def update_fn(params: FilterAndProjectParams, step: int) -> FilterAndProjectParams:
+        """Perform updates to `params` required for the given `step`."""
+        del step
+        return params
+
     return base.Density2DParameterization(
         to_density=to_density_fn,
         from_density=from_density_fn,
         constraints=constraints_fn,
+        update=update_fn,
     )

--- a/src/invrs_opt/parameterization/gaussian_levelset.py
+++ b/src/invrs_opt/parameterization/gaussian_levelset.py
@@ -214,7 +214,7 @@ def gaussian_levelset(
             return params, state
 
         state = init_optimizer.init(params)
-        params, state = jax.lax.fori_loop(
+        params, _ = jax.lax.fori_loop(
             0, init_steps, body_fun=step_fn, init_val=(params, state)
         )
 
@@ -269,10 +269,16 @@ def gaussian_levelset(
         )
         return constraints / length_scale**2
 
+    def update_fn(params: GaussianLevelsetParams, step: int) -> GaussianLevelsetParams:
+        """Perform updates to `params` required for the given `step`."""
+        del step
+        return params
+
     return base.Density2DParameterization(
         to_density=to_density_fn,
         from_density=from_density_fn,
         constraints=constraints_fn,
+        update=update_fn,
     )
 
 

--- a/src/invrs_opt/parameterization/pixel.py
+++ b/src/invrs_opt/parameterization/pixel.py
@@ -38,8 +38,13 @@ def pixel() -> base.Density2DParameterization:
         del params
         return jnp.asarray(0.0)
 
+    def update_fn(params: PixelParams, step: int) -> PixelParams:
+        del step
+        return params
+
     return base.Density2DParameterization(
         from_density=from_density_fn,
         to_density=to_density_fn,
         constraints=constraints_fn,
+        update=update_fn,
     )


### PR DESCRIPTION
Adds an `update` function to the `Density2DParameterization`, which is intended to be called by optimizers following every optimization step. The function has signature `fn(latent_params, step) -> latent_params`, and can be used e.g. with parameterizations that are dependent on the optimization step.

Also modifies the constraint loss function, squaring the constraint arrays. This is expected to yield improved optimization.